### PR TITLE
Allow users to use custom ids in `Node`

### DIFF
--- a/mermaid/flowchart/node.py
+++ b/mermaid/flowchart/node.py
@@ -55,13 +55,17 @@ class Node:
         href (str): The hyperlink reference of the node.
         href_type (str): The type of the hyperlink reference of the node.
     """
-    def __init__(self,
-                 id_: str,
-                 content: str = '',
-                 shape: str = 'normal',
-                 sub_nodes: list['Node'] = None,
-                 href: str = None,
-                 href_type: str = 'blank') -> None:
+    def __init__(
+        self,
+        id_: str,
+        content: str = '',
+        shape: str = 'normal',
+        sub_nodes: list['Node'] = None,
+        href: str = None,
+        href_type: str = 'blank',
+        *,
+        snake_case_id: bool = True,
+    ) -> None:
         """Initialize a new Node.
 
         Args:
@@ -71,8 +75,13 @@ class Node:
             sub_nodes (list[Node]): The sub-nodes of the node.
             href (str): The hyperlink reference of the node.
             href_type (str): The type of the hyperlink reference of the node.
+            snake_case_id (bool): Whether to convert the ID to snake_case (can only be accesed as a keyword argument).
         """
         self.id_: str = text_to_snake_case(id_)
+
+        if not snake_case_id:
+            self.id_ = id_
+
         self.content: str = content if content else id_
         self.shape: NodeShape = NODE_SHAPES[shape]
         self.href: str = href if href is not None else '#'

--- a/mermaid/tests/test_flowchart.py
+++ b/mermaid/tests/test_flowchart.py
@@ -24,7 +24,12 @@ class TestNode(unittest.TestCase):
         self.assertEqual(expect_shape, node.shape)
 
     def test_creating_node_with_out_underscored_id(self):
-        node: Node = Node('.First_Node-1', 'this is my content', 'hexagon')
+        node: Node = Node(
+            '.First_Node-1',
+            'this is my content',
+            'hexagon',
+            snake_case_id=False,
+        )
         expect_id: str = '.First_Node-1'
         expect_content: str = 'this is my content'
         expect_shape: NodeShape = NodeShape('{{', '}}')

--- a/mermaid/tests/test_flowchart.py
+++ b/mermaid/tests/test_flowchart.py
@@ -23,6 +23,15 @@ class TestNode(unittest.TestCase):
         self.assertEqual(expect_content, node.content)
         self.assertEqual(expect_shape, node.shape)
 
+    def test_creating_node_with_out_underscored_id(self):
+        node: Node = Node('.First_Node-1', 'this is my content', 'hexagon')
+        expect_id: str = '.First_Node-1'
+        expect_content: str = 'this is my content'
+        expect_shape: NodeShape = NodeShape('{{', '}}')
+        self.assertEqual(expect_id, node.id_)
+        self.assertEqual(expect_content, node.content)
+        self.assertEqual(expect_shape, node.shape)
+
     def test_string_repr_for_node(self):
         node: Node = Node('First Node', 'this is my content', 'hexagon')
         expect_string: str = 'first_node{{' + '"this is my content"' + '}}'


### PR DESCRIPTION
This resolves #98.

We allow the users to pass a keyword argument to disable the `text_to_snake_case` result and their `id_` as the one assigned for the `Node`.

This is another solution which differs from #99 