### PR TITLE
Fix error while import mermaid in env without Ipython 

### DIFF
--- a/mermaid/__main__.py
+++ b/mermaid/__main__.py
@@ -173,5 +173,4 @@ try:
 
         get_ipython().register_magic_function(mermaidjs, magic_kind="cell")
 except ImportError:
-    # TODO: add a suitible handler for exception.
-    print("Error acured while importing mermaidjs .")
+    print("Warning: IPython is not installed. Mermaidjs magic function is not available.")


### PR DESCRIPTION
Related to #201

Change the error handling code in `mermaid/__main__.py` to display a warning instead of an error.

* Update the error message to "Warning: IPython is not installed. Mermaidjs magic function is not available."

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/ouhammmourachid/mermaid-py/issues/201?shareId=a647323a-986f-403a-ae59-19c0e759f903).